### PR TITLE
disable postgresql by default

### DIFF
--- a/.github/workflows/ci-helm-lint-test.yml
+++ b/.github/workflows/ci-helm-lint-test.yml
@@ -55,4 +55,4 @@ jobs:
           helm install matrix matrix/matrix --values .github/matrix_values.yaml
 
           echo "installing matrix auth service"
-          ct install --target-branch ${{ github.event.repository.default_branch }} --helm-extra-set-args '--set=postgresql.volumePermissions.enabled=false --set=postgresql.primary.networkPolicy.enabled=false --set=syncv3.server=http://matrix-stack-synapse'
+          ct install --target-branch ${{ github.event.repository.default_branch }} --helm-extra-set-args '--set=postgresql.enabled=true --set=postgresql.volumePermissions.enabled=false --set=postgresql.primary.networkPolicy.enabled=false'

--- a/README.md
+++ b/README.md
@@ -21,5 +21,24 @@ helm install my-release-name matrix-authentication-service/matrix-authentication
 ## Notes
 You can find the official docs for the Matrix Authentication Service at [matrix-org.github.io/matrix-authentication-service](https://matrix-org.github.io/matrix-authentication-service/index.html) for now, but this is expected to change to [element-hq.github.io/matrix-authentication-service](https://element-hq.github.io/matrix-authentication-service/index.html) in the near future.
 
+
+### Database
+
+By default, no database is enabled. To enable the built-in Bitnami hosted postgresql sub chart, use:
+
+```yaml
+postgresql:
+  enabled: true
+```
+
+To enable using an external database instead of the built-in sub chart, use:
+
+```yaml
+externalDatabase:
+  enabled: true
+```
+
+**NOTE**: You can only use `externalDatabase.enabled=True` *OR* `postgresql.enabled=True`. You cannot use both. You must pick one. If you're still using Bitnami postgresql, but not the one that is bundled as a subchart to this one, you want to use the `externalDatabase` section.
+
 ## Status
 This chart was developed for use with the [small-hack/matrix-chart](https://github.com/small-hack/matrix-chart). We're still testing this chart. Feel free to open PRs and Issues if you see anything broken or want a feature.

--- a/charts/matrix-authentication-service/Chart.yaml
+++ b/charts/matrix-authentication-service/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.4
+version: 0.1.5
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/matrix-authentication-service/README.md
+++ b/charts/matrix-authentication-service/README.md
@@ -108,7 +108,7 @@ A Helm chart for deploying the matrix authentication service on Kubernetes
 | podAnnotations | object | `{}` |  |
 | podLabels | object | `{}` |  |
 | podSecurityContext | object | `{}` |  |
-| postgresql.enabled | bool | `true` | Whether to deploy the Bitnami Postgresql sub chart If postgresql.enabled is set to true, externalDatabase.enabled must be set to false else if externalDatabase.enabled is set to true, postgresql.enabled must be set to false |
+| postgresql.enabled | bool | `false` | Whether to deploy the Bitnami Postgresql sub chart If postgresql.enabled is set to true, externalDatabase.enabled must be set to false else if externalDatabase.enabled is set to true, postgresql.enabled must be set to false |
 | postgresql.global.postgresql.auth.database | string | `"mas"` | name of the database |
 | postgresql.global.postgresql.auth.existingSecret | string | `""` | Name of existing secret to use for PostgreSQL credentials |
 | postgresql.global.postgresql.auth.password | string | `"changeme"` | password of matrix-authentication-service postgres user - ignored using exsitingSecret |

--- a/charts/matrix-authentication-service/README.md
+++ b/charts/matrix-authentication-service/README.md
@@ -1,6 +1,6 @@
 # matrix-authentication-service
 
-![Version: 0.1.4](https://img.shields.io/badge/Version-0.1.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.9.0](https://img.shields.io/badge/AppVersion-0.9.0-informational?style=flat-square)
+![Version: 0.1.5](https://img.shields.io/badge/Version-0.1.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.9.0](https://img.shields.io/badge/AppVersion-0.9.0-informational?style=flat-square)
 
 A Helm chart for deploying the matrix authentication service on Kubernetes
 

--- a/charts/matrix-authentication-service/values.yaml
+++ b/charts/matrix-authentication-service/values.yaml
@@ -124,7 +124,7 @@ postgresql:
   # -- Whether to deploy the Bitnami Postgresql sub chart
   # If postgresql.enabled is set to true, externalDatabase.enabled must be set to false
   # else if externalDatabase.enabled is set to true, postgresql.enabled must be set to false
-  enabled: true
+  enabled: false
   # persistence:
   #   enabled: false
   volumePermissions:


### PR DESCRIPTION
then users can select which ever they prefer. added note to readme so it's clear:

### Database

By default, no database is enabled. To enable the built-in Bitnami hosted postgresql sub chart, use:

```yaml
postgresql:
  enabled: true
```

To enable using an external database instead of the built-in sub chart, use:

```yaml
externalDatabase:
  enabled: true
```

**NOTE**: You can only use `externalDatabase.enabled=True` *OR* `postgresql.enabled=True`. You cannot use both. You must pick one. If you're still using Bitnami postgresql, but not the one that is bundled as a subchart to this one, you want to use the `externalDatabase` section.