### PR TITLE
update how we do URI templating. if ssl is disabled, use plain text password

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ externalDatabase:
 
 **NOTE**: You can only use `externalDatabase.enabled=True` *OR* `postgresql.enabled=True`. You cannot use both. You must pick one. If you're still using Bitnami postgresql, but not the one that is bundled as a subchart to this one, you want to use the `externalDatabase` section.
 
+**TLS/SSL NOTE**: TLS cannot be enabled for database connections yet due to [matrix-org/matrix-authentication-service:#2799](https://github.com/matrix-org/matrix-authentication-service/issues/2799)
+
 ## Config.yaml
 
 Matrix Authentication Service requires a [`config.yaml`](https://matrix-org.github.io/matrix-authentication-service/reference/configuration.html) to function. You can set it up by either using the values under `mas`, or you can provide your own complete config file via an existing Kubernetes Secret.
@@ -60,3 +62,5 @@ You can also do it an argument to `helm install` with `--set=existingMasConfigSe
 
 ## Status
 This chart was developed for use with the [small-hack/matrix-chart](https://github.com/small-hack/matrix-chart). We're still testing this chart. Feel free to open PRs and Issues if you see anything broken or want a feature.
+
+If the official repo deploys a chart, and it doesn't meet our security needs, we'll submit PRs till it does and when it's in a good state, you can expect this chart to be publicly archived.

--- a/charts/matrix-authentication-service/Chart.yaml
+++ b/charts/matrix-authentication-service/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.5.4
+version: 0.5.5
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/matrix-authentication-service/README.md
+++ b/charts/matrix-authentication-service/README.md
@@ -1,6 +1,6 @@
 # matrix-authentication-service
 
-![Version: 0.5.4](https://img.shields.io/badge/Version-0.5.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: sha-206d45b](https://img.shields.io/badge/AppVersion-sha--206d45b-informational?style=flat-square)
+![Version: 0.5.5](https://img.shields.io/badge/Version-0.5.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: sha-206d45b](https://img.shields.io/badge/AppVersion-sha--206d45b-informational?style=flat-square)
 
 A Helm chart for deploying the matrix authentication service on Kubernetes
 
@@ -42,7 +42,7 @@ A Helm chart for deploying the matrix authentication service on Kubernetes
 | externalDatabase.secretKeys.userPasswordKey | string | `"password"` | key in existingSecret with password for matrix to connect to db |
 | externalDatabase.sslcert | string | `""` | optional: tls/ssl cert for postgresql connections |
 | externalDatabase.sslkey | string | `""` | optional: tls/ssl key for postgresql connections |
-| externalDatabase.sslmode | string | `""` | sslmode to use, example: verify-full |
+| externalDatabase.sslmode | string | `""` | sslmode to use, example: verify-full NOTE: SSL not yet supported due to https://github.com/matrix-org/matrix-authentication-service/issues/2799 |
 | externalDatabase.sslrootcert | string | `""` | optional: tls/ssl root cert for postgresql connections |
 | externalDatabase.username | string | `"mas"` | username of matrix-authentication-service postgres user |
 | extraVolumeMounts | list | `[]` |  |

--- a/charts/matrix-authentication-service/templates/template-script-configmap.yaml
+++ b/charts/matrix-authentication-service/templates/template-script-configmap.yaml
@@ -38,7 +38,7 @@ data:
 
     {{- if not .Values.mas.database.uri }}
     # database section...
-    if [ -z "$PGSSLMODE" ]; then
+    if [ -z "$PGSSLMODE" ] || [ "$PGSSLMODE" == "disable" ]; then
         export PG_URI="postgresql://${PGUSER}:${PGPASSWORD}@${PGHOST}:${PGPORT}/${PGDATABASE}"
     else
         export PG_URI="postgresql://${PGUSER}@${PGHOST}:${PGPORT}/${PGDATABASE}?sslmode=${PGSSLMODE}"

--- a/charts/matrix-authentication-service/values.yaml
+++ b/charts/matrix-authentication-service/values.yaml
@@ -199,6 +199,7 @@ externalDatabase:
   # optional SSL parameters for postgresql, if using your own db instead of the subchart
   # ref: https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-PARAMKEYWORDS
   # -- sslmode to use, example: verify-full
+  # NOTE: SSL not yet supported due to https://github.com/matrix-org/matrix-authentication-service/issues/2799
   sslmode: ""
   # make sure any paths here are reflected in extraVolumes and extraVolumeMounts
   # -- optional: tls/ssl root cert for postgresql connections


### PR DESCRIPTION
before we only detected if sslmode was null/empty string. We now are testing this further because of https://github.com/matrix-org/matrix-authentication-service/issues/2799