### PR TITLE
Respect fullnameOverride setting while declaring initdb-configmap

### DIFF
--- a/charts/matrix-authentication-service/templates/_helpers.tpl
+++ b/charts/matrix-authentication-service/templates/_helpers.tpl
@@ -24,6 +24,40 @@ If release name contains chart name it will be used as a full name.
 {{- end }}
 
 {{/*
+Create a fully qualified PostgreSQL name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "matrix-authentication-service.postgresql.fullname" -}}
+{{- if .Values.postgresql.fullnameOverride }}
+{{- .Values.postgresql.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default "postgresql" .Values.postgresql.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create a fully qualified PostgreSQL name, if run within a tpl function inside of the postgresql subchart.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "postgresql.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default "postgresql" .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
 Create chart name and version as used by the chart label.
 */}}
 {{- define "matrix-authentication-service.chart" -}}

--- a/charts/matrix-authentication-service/templates/initdb-configmap.yaml
+++ b/charts/matrix-authentication-service/templates/initdb-configmap.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ .Release.Name }}-postgresql-initdb
+  name: {{ template "matrix-authentication-service.fullname" . }}-postgresql-initdb
   labels:
   {{ include "matrix-authentication-service.labels" . | nindent 4}}
 data:

--- a/charts/matrix-authentication-service/templates/initdb-configmap.yaml
+++ b/charts/matrix-authentication-service/templates/initdb-configmap.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ template "matrix-authentication-service.postgresql.hostname" . }}-postgresql-initdb
+  name: {{ template "matrix-authentication-service.postgresql.fullname" . }}-postgresql-initdb
   labels:
   {{ include "matrix-authentication-service.labels" . | nindent 4}}
 data:

--- a/charts/matrix-authentication-service/templates/initdb-configmap.yaml
+++ b/charts/matrix-authentication-service/templates/initdb-configmap.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ template "matrix-authentication-service.fullname" . }}-postgresql-initdb
+  name: {{ template "matrix-authentication-service.postgresql.hostname" . }}-postgresql-initdb
   labels:
   {{ include "matrix-authentication-service.labels" . | nindent 4}}
 data:

--- a/charts/matrix-authentication-service/templates/initial-config-secret.yaml
+++ b/charts/matrix-authentication-service/templates/initial-config-secret.yaml
@@ -3,7 +3,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ template "matrix-authentication-service.postgresql.fullname" . }}-initial-config-secret
+  name: {{ template "matrix-authentication-service.fullname" . }}-initial-config-secret
 stringData:
   config.yaml: |
     http:

--- a/charts/matrix-authentication-service/templates/initial-config-secret.yaml
+++ b/charts/matrix-authentication-service/templates/initial-config-secret.yaml
@@ -3,7 +3,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ template "matrix-authentication-service.fullname" . }}-initial-config-secret
+  name: {{ template "matrix-authentication-service.postgresql.fullname" . }}-initial-config-secret
 stringData:
   config.yaml: |
     http:

--- a/charts/matrix-authentication-service/values.yaml
+++ b/charts/matrix-authentication-service/values.yaml
@@ -185,7 +185,7 @@ postgresql:
     # If using an external Postgres server, make sure to configure the database
     # ref: https://github.com/matrix-org/synapse/blob/master/docs/postgres.md
     initdb:
-      scriptsConfigMap: "{{ .Release.Name }}-postgresql-initdb"
+      scriptsConfigMap: {{ template "matrix-authentication-service.fullname" . }}-postgresql-initdb
 
     podSecurityContext:
       enabled: true

--- a/charts/matrix-authentication-service/values.yaml
+++ b/charts/matrix-authentication-service/values.yaml
@@ -183,7 +183,7 @@ postgresql:
   primary:
     # -- run the scripts in templates/postgresql/initdb-configmap.yaml
     # If using an external Postgres server, make sure to configure the database
-    # ref: https://github.com/matrix-org/synapse/blob/master/docs/postgres.md
+    # ref: https://github.com/element-hq/synapse/blob/master/docs/postgres.md
     initdb:
       scriptsConfigMap: '{{ template "postgresql.fullname" . }}-postgresql-initdb'
 

--- a/charts/matrix-authentication-service/values.yaml
+++ b/charts/matrix-authentication-service/values.yaml
@@ -185,7 +185,7 @@ postgresql:
     # If using an external Postgres server, make sure to configure the database
     # ref: https://github.com/matrix-org/synapse/blob/master/docs/postgres.md
     initdb:
-      scriptsConfigMap: {{ template "matrix-authentication-service.fullname" . }}-postgresql-initdb
+      scriptsConfigMap: '{{ template "matrix-authentication-service.fullname" . }}-postgresql-initdb'
 
     podSecurityContext:
       enabled: true

--- a/charts/matrix-authentication-service/values.yaml
+++ b/charts/matrix-authentication-service/values.yaml
@@ -185,7 +185,7 @@ postgresql:
     # If using an external Postgres server, make sure to configure the database
     # ref: https://github.com/matrix-org/synapse/blob/master/docs/postgres.md
     initdb:
-      scriptsConfigMap: '{{ template "matrix-authentication-service.postgresql.hostname" . }}-postgresql-initdb'
+      scriptsConfigMap: '{{ template "postgresql.fullname" . }}-postgresql-initdb'
 
     podSecurityContext:
       enabled: true

--- a/charts/matrix-authentication-service/values.yaml
+++ b/charts/matrix-authentication-service/values.yaml
@@ -185,7 +185,7 @@ postgresql:
     # If using an external Postgres server, make sure to configure the database
     # ref: https://github.com/matrix-org/synapse/blob/master/docs/postgres.md
     initdb:
-      scriptsConfigMap: '{{ template "matrix-authentication-service.fullname" . }}-postgresql-initdb'
+      scriptsConfigMap: '{{ template "matrix-authentication-service.fullname" . }}-initdb'
 
     podSecurityContext:
       enabled: true

--- a/charts/matrix-authentication-service/values.yaml
+++ b/charts/matrix-authentication-service/values.yaml
@@ -185,7 +185,7 @@ postgresql:
     # If using an external Postgres server, make sure to configure the database
     # ref: https://github.com/matrix-org/synapse/blob/master/docs/postgres.md
     initdb:
-      scriptsConfigMap: '{{ template "matrix-authentication-service.fullname" . }}-initdb'
+      scriptsConfigMap: '{{ template "matrix-authentication-service.fullname" . }}-postgresql-initdb'
 
     podSecurityContext:
       enabled: true

--- a/charts/matrix-authentication-service/values.yaml
+++ b/charts/matrix-authentication-service/values.yaml
@@ -185,7 +185,7 @@ postgresql:
     # If using an external Postgres server, make sure to configure the database
     # ref: https://github.com/matrix-org/synapse/blob/master/docs/postgres.md
     initdb:
-      scriptsConfigMap: '{{ template "matrix-authentication-service.fullname" . }}-postgresql-initdb'
+      scriptsConfigMap: '{{ template "matrix-authentication-service.postgresql.hostname" . }}-postgresql-initdb'
 
     podSecurityContext:
       enabled: true


### PR DESCRIPTION
Fixes https://github.com/small-hack/matrix-authentication-service-chart/issues/58#issue-2673134031

Since the postgres subchart doesn't have access to the main applications fullname, the ConfigMap's name is instead based on `postgresql.fullnameOverride` (if one such value is supplied)