### PR TITLE
Use yq for initscript

### DIFF
--- a/charts/matrix-authentication-service/templates/deployment.yaml
+++ b/charts/matrix-authentication-service/templates/deployment.yaml
@@ -66,8 +66,8 @@ spec:
           image: mikefarah/yq:4
           imagePullPolicy: IfNotPresent
           command:
-            - /bin/bash
-            - -exc
+            - /bin/sh
+            - '-exc'
             - /scripts/templateconfig.sh
           volumeMounts:
             - name: templating-script

--- a/charts/matrix-authentication-service/templates/deployment.yaml
+++ b/charts/matrix-authentication-service/templates/deployment.yaml
@@ -74,6 +74,10 @@ spec:
               mountPath: /scripts
             - name: config
               mountPath: /data
+          {{- with .Values.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           env:
             - name: MATRIX_SECRET
               valueFrom:

--- a/charts/matrix-authentication-service/templates/deployment.yaml
+++ b/charts/matrix-authentication-service/templates/deployment.yaml
@@ -63,7 +63,7 @@ spec:
               mountPath: /data
 
         - name: add-secret-values-to-config
-          image: debian:bookworm-slim
+          image: mikefarah/yq:4
           imagePullPolicy: IfNotPresent
           command:
             - /bin/bash

--- a/charts/matrix-authentication-service/templates/template-script-configmap.yaml
+++ b/charts/matrix-authentication-service/templates/template-script-configmap.yaml
@@ -9,20 +9,6 @@ data:
     GREEN='\033[1;32m'
     NC='\033[0m'
 
-    # install stuff
-    echo -e "\n\n ------------INSTALL STUFF-------------- \n\n"
-
-    apt-get update
-    echo -e "${BLUE}installing curl:${NC} ${GREEN}apt-get install curl${NC}"
-    apt-get install -y curl
-
-    echo -e "${BLUE}installing yq...${NC}"
-    YQ_URL="https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64"
-    curl -L "${YQ_URL}" -o /usr/bin/yq && \
-    chmod +x /usr/bin/yq
-
-    echo -e "\n\n ------------END INSTALL STUFF-------------- \n\n"
-
     # templates out the secrets object section of the config.yaml
     export SECRETS=`yq '.secrets' /data/config-secrets.yaml`
     export EXISTING_SECRET=`cat /data/config.yaml | yq .secrets`


### PR DESCRIPTION
This PR makes it such that during the `add-secret-values-to-config` initContainer step, instead of using the `debian:bookworm-slim` image and then installing `yq` onto it, we use the `mikefarah/yq:4` image right away.

My main motivation for this change was that this plays nicer with NetworkPolicies, as the current version requires the user to provide wide-ranging egress access rights to the MAS pod. (And also, it took me a very long time to figure out why the settings didn't populate properly, since the `add-secret-values-to-config` container currently doesn't exit on error - this change is likely going to save NetworkPolicy users a lot of troubleshooting)